### PR TITLE
Quick update to starter shell script so we can run this currently wit…

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -1,5 +1,7 @@
 # !/bin/bash
 
+export NODE_OPTIONS=--openssl-legacy-provider
+
 echo "Install Dependencies"
 yarn install
 


### PR DESCRIPTION
…h more modern iterations of NPM, Node and Yarn

### Resolves

Not exactly a Github issue but something I noticed while working on this for a project, this change will allow more users to be able to run this fork on their local systems by allowing them to use legacy OpenSSL providers.


- Resolves #

### Proposed Changes

In the starter script, a change was made which will allow users for node v17 and above to be able to use this. 

### Reason for Changes

Node v17 and above use different OpenSSL providers, as this project is based on older providers, this change will allow running of the same for users with Node v17 and above.

### Test Coverage

NIL

### Browser Coverage
Check the OS/browser combinations tested (At least 2)

Mac
 * [ ✔] Chrome 
 * [ ] Firefox 
 * [ ✔] Safari
 
Windows
 * [ ] Chrome 
 * [ ] Firefox 
 * [ ] Edge
 
Chromebook
 * [ ] Chrome
 
iPad
* [ ] Safari

Android Tablet
* [ ] Chrome
